### PR TITLE
Add support for controlling Z1 arm mounted on Aliengo quadruped (aliengoZ1 model)

### DIFF
--- a/sim/IOROS.cpp
+++ b/sim/IOROS.cpp
@@ -8,16 +8,21 @@ void RosShutDown(int sig){
 	ros::shutdown();
 }
 
-IOROS::IOROS(){
+IOROS::IOROS() : _rname("z1") {
     std::cout << "The control interface for ROS Gazebo simulation" << std::endl;
     hasGripper = false;
+
+    /* retrieve robot_name from ROS parameter server */
+    ros::param::get("/robot_name", _rname); // defaults to "z1" if parameter not found
+    std::cout << "robot_name: " << _rname << std::endl;
+
     /* start subscriber */
     _initRecv();
     ros::AsyncSpinner subSpinner(1); // one threads
     subSpinner.start();
     usleep(300000);     //wait for subscribers start
     /* initialize publisher */
-    _initSend();   
+    _initSend();
 
     signal(SIGINT, RosShutDown);
 
@@ -65,23 +70,23 @@ void IOROS::_recvState(LowlevelState *state){
 }
 
 void IOROS::_initSend(){
-    _servo_pub[0] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/z1_gazebo/Joint01_controller/command", 1);
-    _servo_pub[1] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/z1_gazebo/Joint02_controller/command", 1);
-    _servo_pub[2] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/z1_gazebo/Joint03_controller/command", 1);
-    _servo_pub[3] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/z1_gazebo/Joint04_controller/command", 1);
-    _servo_pub[4] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/z1_gazebo/Joint05_controller/command", 1);
-    _servo_pub[5] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/z1_gazebo/Joint06_controller/command", 1);
-    _servo_pub[6] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/z1_gazebo/gripper_controller/command", 1);
+    _servo_pub[0] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/" + _rname + "_gazebo/Joint01_controller/command", 1);
+    _servo_pub[1] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/" + _rname + "_gazebo/Joint02_controller/command", 1);
+    _servo_pub[2] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/" + _rname + "_gazebo/Joint03_controller/command", 1);
+    _servo_pub[3] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/" + _rname + "_gazebo/Joint04_controller/command", 1);
+    _servo_pub[4] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/" + _rname + "_gazebo/Joint05_controller/command", 1);
+    _servo_pub[5] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/" + _rname + "_gazebo/Joint06_controller/command", 1);
+    _servo_pub[6] = _nm.advertise<unitree_legged_msgs::MotorCmd>("/" + _rname + "_gazebo/gripper_controller/command", 1);
 }
 
 void IOROS::_initRecv(){
-    _servo_sub[0] = _nm.subscribe("/z1_gazebo/Joint01_controller/state", 1, &IOROS::_joint00Callback, this);
-    _servo_sub[1] = _nm.subscribe("/z1_gazebo/Joint02_controller/state", 1, &IOROS::_joint01Callback, this);
-    _servo_sub[2] = _nm.subscribe("/z1_gazebo/Joint03_controller/state", 1, &IOROS::_joint02Callback, this);
-    _servo_sub[3] = _nm.subscribe("/z1_gazebo/Joint04_controller/state", 1, &IOROS::_joint03Callback, this);
-    _servo_sub[4] = _nm.subscribe("/z1_gazebo/Joint05_controller/state", 1, &IOROS::_joint04Callback, this);
-    _servo_sub[5] = _nm.subscribe("/z1_gazebo/Joint06_controller/state", 1, &IOROS::_joint05Callback, this);
-    _servo_sub[6] = _nm.subscribe("/z1_gazebo/gripper_controller/state", 1, &IOROS::_gripperCallback, this);
+    _servo_sub[0] = _nm.subscribe("/" + _rname + "_gazebo/Joint01_controller/state", 1, &IOROS::_joint00Callback, this);
+    _servo_sub[1] = _nm.subscribe("/" + _rname + "_gazebo/Joint02_controller/state", 1, &IOROS::_joint01Callback, this);
+    _servo_sub[2] = _nm.subscribe("/" + _rname + "_gazebo/Joint03_controller/state", 1, &IOROS::_joint02Callback, this);
+    _servo_sub[3] = _nm.subscribe("/" + _rname + "_gazebo/Joint04_controller/state", 1, &IOROS::_joint03Callback, this);
+    _servo_sub[4] = _nm.subscribe("/" + _rname + "_gazebo/Joint05_controller/state", 1, &IOROS::_joint04Callback, this);
+    _servo_sub[5] = _nm.subscribe("/" + _rname + "_gazebo/Joint06_controller/state", 1, &IOROS::_joint05Callback, this);
+    _servo_sub[6] = _nm.subscribe("/" + _rname + "_gazebo/gripper_controller/state", 1, &IOROS::_gripperCallback, this);
 }
 
 void IOROS::_joint00Callback(const unitree_legged_msgs::MotorState& msg){

--- a/sim/IOROS.h
+++ b/sim/IOROS.h
@@ -13,6 +13,7 @@ public:
     bool sendRecv(const LowlevelCmd *cmd, LowlevelState *state);
 private:
     ros::NodeHandle _nm;
+    std::string _rname; // robot_name retrieved from ROS parameter server
     ros::Subscriber _servo_sub[7];
     ros::Publisher _servo_pub[7];
     unitree_legged_msgs::MotorState _joint_state[7];


### PR DESCRIPTION
This pull request addresses issue #6 by extending support for controlling the Unitree Z1 robotic arm when it is mounted on a quadruped; e.g., using the [`aliengoZ1_description`](https://github.com/unitreerobotics/unitree_ros/tree/602965797b1df958066b31e859e2296c62044098/robots/aliengoZ1_description) model in [`unitree_ros`](https://github.com/unitreerobotics/unitree_ros).

### Issue:
| ![aliengoZ1_failure](https://github.com/unitreerobotics/z1_controller/assets/8316042/e88245b1-4335-4dcf-a323-aab22f75e48b) |
| :---: |
| *Failed attempt to control Z1 arm joints within `aliengoZ1_description` in Gazebo* |

Currently, the `z1_controller` repository provides a ROS control interface for the Unitree Z1 robotic arm in the `/z1_gazebo` namespace:

| ![z1](https://github.com/paulblum/z1_controller/assets/8316042/5810e741-4d13-40b7-91a5-e0655b380418) |
| :---: |
| *Relevant ROS nodes and topics during operation of `z1_description` in Gazebo by `z1_controller`* |

However, there is a need to extend support for controlling the Z1 arm when it is mounted on a quadruped model with a *different* namespace. For example, using the [`aliengoZ1_description`](https://github.com/unitreerobotics/unitree_ros/tree/602965797b1df958066b31e859e2296c62044098/robots/aliengoZ1_description) model where the namespace is `/aliengoZ1_gazebo`:

| ![aZ1](https://github.com/paulblum/z1_controller/assets/8316042/f23218ad-f970-4993-8fe7-3d5ea287efe5) |
| :---: |
| *Relevant ROS nodes and topics during attempted operation of Z1 arm within `aliengoZ1_description` in Gazebo by `z1_controller`; note dead and leaf topics due to namespace mismatch* |

The issue stems from a hard-coding of the `/z1_gazebo` namespace within the Z1 control interface for ROS Gazebo simulation, [`IOROS`](https://github.com/unitreerobotics/z1_controller/blob/8eb659565802c9df6ddc8a3121aa9d85a5670404/sim/IOROS.cpp):

https://github.com/unitreerobotics/z1_controller/blob/8eb659565802c9df6ddc8a3121aa9d85a5670404/sim/IOROS.cpp#L67-L85

### Proposed Changes:
Implement a mechanism to automatically detect the correct namespace based on the model being used when `z1_controller` begins execution, and use it to configure the namespace of ROS topics for Z1 joint control.

#### Insights:
- Unitree's quadruped models (e.g., `aliengoZ1_description`) [initialize a ROS parameter called `/robot_name`](https://github.com/unitreerobotics/unitree_ros/blob/602965797b1df958066b31e859e2296c62044098/robots/aliengoZ1_description/launch/aliengoZ1_gazebo.launch#L69-L72) in their launch files, each specifying a model's unique namespace.
- The `/robot_name` parameter can be retrieved and used to configure the `IOROS` interface with the correct namespace for Z1 joints.
    - Similar to Unitree's implementations in [**servo.cpp**](https://github.com/unitreerobotics/unitree_ros/blob/602965797b1df958066b31e859e2296c62044098/unitree_controller/src/servo.cpp#L210-L212) and [**move_publisher.cpp**](https://github.com/unitreerobotics/unitree_ros/blob/602965797b1df958066b31e859e2296c62044098/unitree_controller/src/move_publisher.cpp#L26-L28).
- Note that [**z1.launch**](https://github.com/unitreerobotics/unitree_ros/blob/602965797b1df958066b31e859e2296c62044098/unitree_gazebo/launch/z1.launch) does not initialize a `/robot_name` parameter; the original `/z1_gazebo` namespace should be used in this case.

#### Implementation details:
- Added a private member variable `_rname` of type `std::string` to the `IOROS` class.
    - During `IOROS` initialization, `_rname` stores `/robot_name` retrieved from the ROS parameter server, defaulting to `"z1"` if no such parameter is found.
- `_rname` configures the namespace for Z1 joints whenever `IOROS::_initSend()` or `IOROS::_initRecv()` are invoked.

### Results:
The modification maintains `z1_controller`'s functionality for control of [`z1_description`](https://github.com/unitreerobotics/unitree_ros/tree/602965797b1df958066b31e859e2296c62044098/robots/z1_description) in Gazebo, while enabling the capability of `z1_controller` to control the Z1 arm when it exists in a different robot namespace:

| ![fixed_z1](https://github.com/paulblum/z1_controller/assets/8316042/b7a8faf3-a17b-46f0-acbd-e0b8c8c4d0da) | ![fixed_aZ1](https://github.com/paulblum/z1_controller/assets/8316042/b98ae85f-2f84-4413-9074-4e7520fd67ed) |
| :---: | :---: |
| *Relevant ROS nodes and topics during operation of `z1_description` in Gazebo by updated `z1_controller`* | *Relevant ROS nodes and topics during successful operation of Z1 arm within `aliengoZ1_description` in Gazebo by updated `z1_controller`* |

| ![aliengoZ1](https://github.com/paulblum/z1_controller/assets/8316042/7afc7d88-d4dc-4f88-b1b6-3d5918a37b67) |
| :---: |
| *Update enables simultaneous control of quadruped and Z1 arm joints in Gazebo; `unitree_servo` and `z1_controller`'s demo trajectory visualized here* |